### PR TITLE
EXTENSION: Remove MVD_PEXT1_EZCSQC.

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -69,7 +69,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 # define MVD_PEXT1_HIDDEN_MESSAGES   (1 <<  5) // dem_multiple(0) packets are in format (<length> <type-id>+ <packet-data>)*
 //# define MVD_PEXT1_SERVERSIDEWEAPON2 (1 <<  6) // Server-side weapon selection supports clc_mvd_weapon_full_impulse.
 												 // Can be defined in a project Makefile
-# define MVD_PEXT1_EZCSQC            (1 << 7)  // Marker extension for the hardcoded ezQuake side KTX CSQC code
 
 # if defined(MVD_PEXT1_DEBUG_ANTILAG) || defined(MVD_PEXT1_DEBUG_WEAPON)
 #  define MVD_PEXT1_DEBUG


### PR DESCRIPTION
This will not be needed for the hardcoded CSQC support in ezQuake and will only be annoying for other clients. Can check client info and manage dynamically instead.